### PR TITLE
added missing dependency for conan and added gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/.idea
+/composer.phar
+/vendor/

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
     ],
     "require": {
       "fm/conan-bundle": "dev-master",
+      "knplabs/knp-menu": "2.0.*@dev",
       "psr/log": "~1.0"
     },
     "autoload": {


### PR DESCRIPTION
FYI; Conan can't be intalled without manually including the knplabs/knp-menu dependency as that package is not yet stable; that's why I modified the `composer.json` to include it.
